### PR TITLE
set models path in consturctor

### DIFF
--- a/src/Arabic.php
+++ b/src/Arabic.php
@@ -17,7 +17,7 @@ class Arabic
     /**
      * @var string
      */
-    private $_modelPath = __DIR__.'/Models';
+    private $_modelPath;
 
     /**
      * Init all support services
@@ -49,7 +49,10 @@ class Arabic
     {
         //Set internal character encoding to UTF-8
         mb_internal_encoding("utf-8");
-
+        
+        // set models path
+        $this->_modelPath = __DIR__.'/Models';
+        
         $this->loadAllModels();
 
         // Bind all services as arabic class parameter


### PR DESCRIPTION
in php version  < 5.6 using **__DIR__** or something like that in defining the properties area is not allowed with expecting ; exception.
